### PR TITLE
fix(infra): network not attaching on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-aws-nat-instance [![CircleCI](https://circleci.com/gh/int128/terraform-aws-nat-instance.svg?style=shield)](https://circleci.com/gh/int128/terraform-aws-nat-instance)
 
+## NOTE: This was forked to address repeated NAT outages caused by [this issue](https://github.com/int128/terraform-aws-nat-instance/issues/57). Source repo appears to be abandoned.
+
 This is a Terraform module which provisions a NAT instance.
 
 Features:

--- a/runonce.sh
+++ b/runonce.sh
@@ -1,11 +1,17 @@
 #!/bin/bash -x
 
+echo -e "\n\nattaching ENI from $(realpath $0)\n"
+
 # attach the ENI
-aws ec2 attach-network-interface \
-  --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
-  --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
-  --device-index 1 \
-  --network-interface-id "${eni_id}"
+end_time=$((SECONDS + 180))
+while [ $SECONDS -lt $end_time ] && ! ip link show dev eth1; do
+  aws ec2 attach-network-interface \
+    --region "$(/opt/aws/bin/ec2-metadata -z  | sed 's/placement: \(.*\).$/\1/')" \
+    --instance-id "$(/opt/aws/bin/ec2-metadata -i | cut -d' ' -f2)" \
+    --device-index 1 \
+    --network-interface-id "${eni_id}"
+    sleep 1
+done
 
 # start SNAT
 systemctl enable snat

--- a/snat.sh
+++ b/snat.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -x
 
+echo -e "\n\nconfiguring network from $(realpath $0)\n"
+
 # wait for eth1
 while ! ip link show dev eth1; do
   sleep 1


### PR DESCRIPTION
Fixing this [upstream issue](https://github.com/int128/terraform-aws-nat-instance/issues/57) by implementing [this PR](https://github.com/int128/terraform-aws-nat-instance/pull/72/files).